### PR TITLE
Remove `attr_accessor` from Entry post `protected_attributes` gem

### DIFF
--- a/lib/health-data-standards/models/entry.rb
+++ b/lib/health-data-standards/models/entry.rb
@@ -24,11 +24,6 @@ class Entry
   field :oid, type: String
   field :reason, type: Hash
 
-  attr_accessor :version
-  attr_accessor :_id
-  attr_accessor :created_at
-  attr_accessor :updated_at
-
   def add_reference(entry, type)
     references.build(type: type, referenced_type: entry.class, referenced_id: entry.id)
   end


### PR DESCRIPTION
After removing the `protected_attributes` gem in PR #3, also remove the `attr_accessor` fields. These may or may not conflict with Mongo's default document fields. Since the tests pass either way, let's be conservative and remove them.
