### PR TITLE
Create rake task to clean out dummy data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,14 @@ You should see a success message similar to:
     Extensions Loaded: 2
     Value Sets Loaded: 799
 
-If you want to remove all of the effects of the import to start over, run:
+If you want to use your own real data, it would behoove you to remove the
+existing dummy data created during the import process to avoid conflicts:
 
-`rake bundle:reset`
+`rake bundle:cleanup`
+
+If you want to remove all of the bundle artifacts to start over from scratch:
+
+`rake bundle:uninstall`
 
 Project Practices
 =================

--- a/lib/health-data-standards/tasks/bundle.rake
+++ b/lib/health-data-standards/tasks/bundle.rake
@@ -227,15 +227,26 @@ namespace :bundle do
   end
 
   desc 'Remove all artifacts from NLM import process'
-  task :reset => :environment do
-    [Record,
-     HealthDataStandards::CQM::Bundle,
-     HealthDataStandards::CQM::Measure,
-     HealthDataStandards::CQM::PatientCache,
-     HealthDataStandards::CQM::QueryCache,
-     HealthDataStandards::SVS::ValueSet].each do |klass|
-       num_deleted = klass.delete_all
-       puts "#{klass.name}: Deleted [#{num_deleted}] records"
-     end
+  task uninstall: :environment do
+    Rake::Task['bundle:cleanup'].execute
+    [
+      HealthDataStandards::CQM::Bundle,
+      HealthDataStandards::CQM::Measure,
+      HealthDataStandards::SVS::ValueSet
+    ].each { |klass| clean_bundle_klass(klass) }
+  end
+
+  desc 'Remove all dummy data from NLM import process'
+  task cleanup: :environment do
+    [
+      Record,
+      HealthDataStandards::CQM::PatientCache,
+      HealthDataStandards::CQM::QueryCache
+    ].each { |klass| clean_bundle_klass(klass) }
+  end
+
+  def clean_bundle_klass(klass)
+    num_deleted = klass.delete_all
+    puts "#{klass.name}: Deleted [#{num_deleted}] records"
   end
 end


### PR DESCRIPTION
In order to start with a clean slate after importing the bundle, we need to delete a number of existing dummy records created by the import process. This new `bundle:cleanup` rake task will allow us to start fresh after either the first bundle install (#110669210), or even between imports of our own data in dev if we so choose (#112362835).

Also, rename the previous `bundle:reset` task to `bundle:uninstall` to be the counter-weight to the `bundle:download_and_install`. Use `bundle:cleanup` as part of `bundle:uninstall` to avoid duplication.
