### PR TITLE
Raise `HQMF` to global level

### DIFF
--- a/lib/health-data-standards/models/cqm/measure.rb
+++ b/lib/health-data-standards/models/cqm/measure.rb
@@ -94,7 +94,7 @@ module HealthDataStandards
       # Returns the hqmf-parser's ruby implementation of an HQMF document.
       # Rebuild from population_criteria, data_criteria, and measure_period JSON
       def as_hqmf_model
-        @hqmf ||=  HQMF::Document.from_json(self.hqmf_document)
+        @hqmf ||=  ::HQMF::Document.from_json(self.hqmf_document)
       end
 
       def key


### PR DESCRIPTION
Inside `Measure`, referencing `HQMF` assumes it lives in the same namespace; however, when we are using this gem for [external Cypress validation](https://github.com/q-centrix/cypress/pull/2), we categorize it under a different namespace. This change prevents an improper namespace search and ensures we can find `HQMF` during validation.
