### PR TITLE
Return newly-created Record object after BulkRecordImporter.import

### DIFF
--- a/lib/health-data-standards/import/bulk_record_importer.rb
+++ b/lib/health-data-standards/import/bulk_record_importer.rb
@@ -128,6 +128,7 @@ module HealthDataStandards
         end
         record.save
 
+        record
       end
     end
   end


### PR DESCRIPTION
In order to be able to use the newly-created `Record` instance from outside the bulk importer _without_ introducing a race condition with `Record.last`, return the newly-created record object from the import method.

**Note:** This used to return `true`, so whoever is using it can still expect a truthy check to be valid (e.g., `if BulkRecordImporter.import`); however, any specific checks (e.g., if `BulkRecordImporter.import == true`) will no longer work. Since we are the only ones using this at the moment, however, this is acceptable, and for sure perferable to the other hoops we were jumping through in order to find the newly-created `Record` object.
