### PR TITLE
[WIP] Add facility_id to facilitate (pun intended) multitenancy

### DIFF
--- a/lib/health-data-standards/export/cat_3.rb
+++ b/lib/health-data-standards/export/cat_3.rb
@@ -9,10 +9,10 @@ module HealthDataStandards
         @cat1_renderer.template_helper = HealthDataStandards::Export::TemplateHelper.new('cat1', 'cat1')
       end
 
-      def export(measures, header, effective_date, start_date, end_date, filter=nil,test_id=nil)
+      def export(measures, header, effective_date, start_date, end_date, filter=nil,test_id=nil, facility_id=nil)
         results = {}
         measures.each do |measure|
-          results[measure['hqmf_id']] = HealthDataStandards::CQM::QueryCache.aggregate_measure(measure['hqmf_id'], effective_date, filter, test_id)
+          results[measure['hqmf_id']] = HealthDataStandards::CQM::QueryCache.aggregate_measure(measure['hqmf_id'], effective_date, filter, test_id, facility_id)
         end
         @rendering_context.render(:template => 'show', 
                                   :locals => {:measures => measures, :start_date => start_date, 

--- a/lib/health-data-standards/models/cqm/patient_cache.rb
+++ b/lib/health-data-standards/models/cqm/patient_cache.rb
@@ -10,7 +10,7 @@ module HealthDataStandards
       embeds_one :value, class_name: "HealthDataStandards::CQM::PatientCacheValue", inverse_of: :patient_cache
 
       def record
-        Record.where(:medical_record_number => value['medical_record_id'], :test_id => value["test_id"]).first
+        Record.where(:medical_record_number => value['medical_record_id'], :test_id => value["test_id"], :facility_id => value["facility_id"]).first
       end
 
       def self.smoking_gun_rational(hqmf_id, sub_ids=nil, filter ={})

--- a/lib/health-data-standards/models/cqm/query_cache.rb
+++ b/lib/health-data-standards/models/cqm/query_cache.rb
@@ -22,9 +22,9 @@ module HealthDataStandards
       field :OBSERV, type: Float
       field :supplemental_data, type: Hash
 
-      def self.aggregate_measure(measure_id, effective_date, filters=nil, test_id=nil)
+      def self.aggregate_measure(measure_id, effective_date, filters=nil, test_id=nil, facility_id=nil)
         query_hash = {'effective_date' => effective_date, 'measure_id' => measure_id,
-                      'test_id' => test_id}
+                      'test_id' => test_id, 'facility_id' => facility_id}
         if filters
           query_hash.merge!(filters)
         end

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -16,6 +16,7 @@ class Record
   field :ethnicity, type: Hash
   field :languages, type: Array, default: []
   field :test_id, type: BSON::ObjectId
+  field :facility_id, type: String
   field :marital_status, type: Hash
   field :medical_record_number, type: String
   field :medical_record_assigner, type: String
@@ -24,6 +25,7 @@ class Record
   index "last" => 1
   index medical_record_number: 1
   index test_id: 1
+  index facility_id: 1
   index bundle_id: 1
   embeds_many :allergies
   embeds_many :care_goals, class_name: "Entry" # This can be any number of different entry types


### PR DESCRIPTION
In order to be able to segregate Records / PatientCaches by facility, add facility_id to the entire pipeline, including Record, PatientCache, QueryCache, and Cat3 Exporter. We looked at hijacking this through test_id but at the end of the day we decided to go with adding our own attribute.
