### PR TITLE
Changes the demo server address

### DIFF
--- a/lib/health-data-standards/tasks/bundle.rake
+++ b/lib/health-data-standards/tasks/bundle.rake
@@ -50,7 +50,7 @@ namespace :bundle do
 
     puts "Downloading and saving #{@bundle_name} to #{measures_dir}"
     # Pull down the list of bundles and download the version we're looking for
-    bundle_uri = "https://demo.projectcypress.org/bundles/#{@bundle_name}"
+    bundle_uri = "https://cypressdemo.healthit.gov/measure_bundles/#{@bundle_name}"
     bundle = nil
 
     tries = 0


### PR DESCRIPTION
The demo server address has changed for downloading g the bundles. This
changes the address to match the new one.

It should also be noted that ENV["version"] must be specified now as
well since "bundle-latest.zip" is not an existing concept anymore.

https://github.com/projectcypress/health-data-standards/issues/426
