### PR TITLE
features/delete patient before import [134378119]

### DIFF
--- a/lib/health-data-standards/import/bulk_record_importer.rb
+++ b/lib/health-data-standards/import/bulk_record_importer.rb
@@ -80,7 +80,7 @@ module HealthDataStandards
 
       def self.import_json(data,provider_map = {})
         json = JSON.parse(data,:max_nesting=>100)
-        record = Record.update_or_create(Record.new(json))
+        record = Record.delete_and_create(Record.new(json))
         providers = record.provider_performances
         providers.each do |prov|
           prov.provider.ancestors.each do |ancestor|
@@ -112,7 +112,7 @@ module HealthDataStandards
           end
 
           patient_data.facility_id = facility_id
-          record = Record.update_or_create(patient_data)
+          record = Record.delete_and_create(patient_data)
 
           begin
             providers = CDA::ProviderImporter.instance.extract_providers(doc, record)

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -61,7 +61,8 @@ class Record
   scope :by_patient_id, ->(id) { where(:medical_record_number => id) }
 
   def self.delete_and_create(data)
-    Record.destroy_all(medical_record_number: data.medical_record_number, facility_id: data.facility_id)
+    destroy_all(medical_record_number: data.medical_record_number,
+                facility_id: data.facility_id)
     data.save!
     data
   end

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -60,15 +60,12 @@ class Record
   scope :by_provider, ->(prov, effective_date) { (effective_date) ? where(provider_queries(prov.id, effective_date)) : where('provider_performances.provider_id'=>prov.id)  }
   scope :by_patient_id, ->(id) { where(:medical_record_number => id) }
 
-  def self.update_or_create(data)
-    existing = Record.where(medical_record_number: data.medical_record_number, facility_id: data.facility_id).first
-    if existing
-      existing.update_attributes!(data.attributes.except('_id'))
-      existing
-    else
+  def self.delete_and_create(data)
+    Record.transaction do
+      Record.destroy_all(medical_record_number: data.medical_record_number)
       data.save!
-      data
     end
+    data
   end
 
   def providers

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -60,6 +60,17 @@ class Record
   scope :by_provider, ->(prov, effective_date) { (effective_date) ? where(provider_queries(prov.id, effective_date)) : where('provider_performances.provider_id'=>prov.id)  }
   scope :by_patient_id, ->(id) { where(:medical_record_number => id) }
 
+  def self.update_or_create(data)
+    existing = Record.where(medical_record_number: data.medical_record_number, facility_id: data.facility_id).first
+    if existing
+      existing.update_attributes!(data.attributes.except('_id'))
+      existing
+    else
+      data.save!
+      data
+    end
+  end
+
   def self.delete_and_create(data)
     destroy_all(medical_record_number: data.medical_record_number,
                 facility_id: data.facility_id)

--- a/lib/health-data-standards/models/record.rb
+++ b/lib/health-data-standards/models/record.rb
@@ -61,10 +61,8 @@ class Record
   scope :by_patient_id, ->(id) { where(:medical_record_number => id) }
 
   def self.delete_and_create(data)
-    Record.transaction do
-      Record.destroy_all(medical_record_number: data.medical_record_number)
-      data.save!
-    end
+    Record.destroy_all(medical_record_number: data.medical_record_number, facility_id: data.facility_id)
+    data.save!
     data
   end
 

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -134,8 +134,7 @@ class RecordTest < Minitest::Test
 
     new_record = Record.delete_and_create(record)
 
-    assert_not_equal first_record, new_record
-
+    wont_equal first_record, new_record
     assert_equal Record.where(medical_record_number: '1235').count, 1
   end
 end

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -108,6 +108,26 @@ class RecordTest < Minitest::Test
     assert_equal 29, record.medications.size
   end
 
+  def test_update_or_create_for_new_record
+    first_record = FactoryGirl.create(:empty_record, facility_id: 1, medical_record_number: "1234")
+    record = FactoryGirl.build(:empty_record, facility_id: 2, medical_record_number: "1234")
+
+    new_record = Record.update_or_create(record)
+
+    refute_equal first_record, new_record
+    assert_equal Record.where(medical_record_number: "1234").count, 2
+  end
+
+  def test_update_or_create_for_existing_record
+    first_record = FactoryGirl.create(:empty_record, facility_id: 3, medical_record_number: "1235")
+    record = FactoryGirl.build(:empty_record, facility_id: 3, medical_record_number: "1235")
+
+    new_record = Record.update_or_create(record)
+
+    assert_equal first_record, new_record
+    assert_equal Record.where(medical_record_number: "1235").count, 1
+  end
+
   def test_delete_and_create_for_new_record
     first_record = FactoryGirl.create(:empty_record,
                                       facility_id: 1,

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -134,7 +134,7 @@ class RecordTest < Minitest::Test
 
     new_record = Record.delete_and_create(record)
 
-    wont_equal first_record, new_record
+    refute_equal first_record, new_record
     assert_equal Record.where(medical_record_number: '1235').count, 1
   end
 end

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -108,23 +108,34 @@ class RecordTest < Minitest::Test
     assert_equal 29, record.medications.size
   end
 
-  def test_update_or_create_for_new_record
-    first_record = FactoryGirl.create(:empty_record, facility_id: 1, medical_record_number: "1234")
-    record = FactoryGirl.build(:empty_record, facility_id: 2, medical_record_number: "1234")
+  def test_delete_and_create_for_new_record
+    first_record = FactoryGirl.create(:empty_record,
+                                      facility_id: 1,
+                                      medical_record_number: '1234')
 
-    new_record = Record.update_or_create(record)
+    record = FactoryGirl.build(:empty_record,
+                               facility_id: 2,
+                               medical_record_number: '1234')
+
+    new_record = Record.delete_and_create(record)
 
     refute_equal first_record, new_record
-    assert_equal Record.where(medical_record_number: "1234").count, 2
+    assert_equal Record.where(medical_record_number: '1234').count, 2
   end
 
-  def test_update_or_create_for_existing_record
-    first_record = FactoryGirl.create(:empty_record, facility_id: 3, medical_record_number: "1235")
-    record = FactoryGirl.build(:empty_record, facility_id: 3, medical_record_number: "1235")
+  def test_delete_and_create_for_existing_record
+    first_record = FactoryGirl.create(:empty_record,
+                                      facility_id: 3,
+                                      medical_record_number: '1235')
 
-    new_record = Record.update_or_create(record)
+    record = FactoryGirl.build(:empty_record,
+                               facility_id: 3,
+                               medical_record_number: '1235')
 
-    assert_equal first_record, new_record
-    assert_equal Record.where(medical_record_number: "1235").count, 1
+    new_record = Record.delete_and_create(record)
+
+    assert_not_equal first_record, new_record
+
+    assert_equal Record.where(medical_record_number: '1235').count, 1
   end
 end


### PR DESCRIPTION
**Pivotal Story**
[https://www.pivotaltracker.com/story/show/134378119](https://www.pivotaltracker.com/story/show/134378119)

**Updates**

* Refactored create procedure to `delete_and_create`
* Refactored specs to verify records are deleted before created

**Specs**
```
Finished in 339.59678s
409 tests, 1973 assertions, 0 failures, 0 errors, 101 skips
Coverage report generated for Unit Tests to /Users/chrishough/Zeal/code/clients/q-centrix-health-data-standards/coverage. 6599 / 7281 LOC (90.63%) covered.
Coverage report generated for Unit Tests to /Users/chrishough/Zeal/code/clients/q-centrix-health-data-standards/coverage. 2529 / 7379 LOC (34.27%) covered.
```