### PR TITLE
Remove sample patient import

### DIFF
--- a/lib/health-data-standards/tasks/bundle.rake
+++ b/lib/health-data-standards/tasks/bundle.rake
@@ -100,7 +100,7 @@ namespace :bundle do
     de = ENV['delete_existing'] || false
     um = ENV['update_measures'] || false
     puts "Importing bundle #{@bundle_name} delete_existing: #{de}  update_measures: #{um} type: #{ENV['type'] || 'ALL'}"
-    task("bundle:import").invoke("bundles/#{@bundle_name}",de, um , ENV['type'], 'true')
+    task("bundle:import").invoke("bundles/#{@bundle_name}",de, um , ENV['type'], 'true', 'true')
   end
 
 


### PR DESCRIPTION
When using the bundles from the website the system imports the results which includes sample patients. This is not really desirable and can be skipped safely.