### PR TITLE
 Override data_criteria method on measures

### DIFF
--- a/lib/health-data-standards/models/cqm/measure.rb
+++ b/lib/health-data-standards/models/cqm/measure.rb
@@ -144,6 +144,11 @@ module HealthDataStandards
         self.name
       end
 
+      def data_criteria
+        return self['data_criteria'] if self['data_criteria'].any?
+        [hqmf_document['data_criteria']]
+      end
+
       def all_data_criteria
         return @crit if @crit
         @crit = []

--- a/test/unit/models/cqm/measure_test.rb
+++ b/test/unit/models/cqm/measure_test.rb
@@ -46,6 +46,14 @@ class MeasureTest < ActiveSupport::TestCase
     assert measures.where(:hqmf_id=>"0348").count() == 1, "Top level measure 0348 Not Found"
   end
 
+  test "#data_criteria returns correct value" do
+    @measure.data_criteria = [1, 2, 3]
+    assert_equal [1, 2, 3], @measure.data_criteria
+
+    @measure.data_criteria = []
+    @measure.hqmf_document = { 'data_criteria' => { 1 => 2, 3 => 4 } }
+    assert_equal [{ 1 => 2, 3 => 4 }], @measure.data_criteria
+  end
 
   test "all data criteria" do
     adc = @measure.all_data_criteria


### PR DESCRIPTION
When using the measures that we are importing they do not have a
data_criteria object. That object does exist inside the hqmf_document
element of the measure. This will return that object instead if the
original data_criteria method returns no elements.

https://www.pivotaltracker.com/story/show/128693249